### PR TITLE
Add agent profile loader example

### DIFF
--- a/scripts/print_agent_info.py
+++ b/scripts/print_agent_info.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Utility script to display basic agent information."""
+import argparse
+from pathlib import Path
+
+from gaia_qao.agent import load_agent_profile
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Display agent profile info")
+    parser.add_argument(
+        "profile",
+        type=Path,
+        default=Path("Q-AI/agent_profile_sustainability.yaml"),
+        nargs="?",
+        help="Path to agent profile YAML",
+    )
+    args = parser.parse_args()
+
+    profile = load_agent_profile(args.profile)
+    print(f"Agent ID: {profile.agent_id}")
+    print(f"Agent Name: {profile.agent_name}")
+    print(f"Description: {profile.description}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gaia_qao/__init__.py
+++ b/src/gaia_qao/__init__.py
@@ -1,0 +1,1 @@
+"""GAIA-QAO core utilities."""

--- a/src/gaia_qao/agent.py
+++ b/src/gaia_qao/agent.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+@dataclass
+class AgentProfile:
+    """Simple representation of an agent profile."""
+
+    agent_id: str
+    agent_name: str
+    description: str
+    metadata: Dict[str, Any]
+
+
+def load_agent_profile(path: Path) -> AgentProfile:
+    """Load an agent profile from a YAML file."""
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    return AgentProfile(
+        agent_id=data.get("agent_id", ""),
+        agent_name=data.get("agent_name", ""),
+        description=data.get("description", {}).get("summary", ""),
+        metadata=data.get("metadata", {}),
+    )

--- a/tests/test_agent_reader.py
+++ b/tests/test_agent_reader.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+from gaia_qao.agent import load_agent_profile
+
+
+def test_load_agent_profile():
+    profile = load_agent_profile(Path("Q-AI/agent_profile_sustainability.yaml"))
+    assert profile.agent_id == "agent-env-sustainability-001"
+    assert profile.agent_name == "Environmental Sustainability Specialist"


### PR DESCRIPTION
## Summary
- start a minimal Python package `gaia_qao`
- add a YAML agent profile loader
- provide a simple CLI script to print agent info
- include a basic pytest for the loader

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*